### PR TITLE
WILD-003 : Tests -  Ajout des tests pour le Resolver History et pour le système de requêtes d'URL

### DIFF
--- a/back/.gitignore
+++ b/back/.gitignore
@@ -2,3 +2,4 @@
 pnpm-lock.yaml
 package-lock.json
 node_modules
+coverage

--- a/back/jest.config.ts
+++ b/back/jest.config.ts
@@ -198,4 +198,3 @@ const config: Config = {
 };
 
 export default config;
-

--- a/back/jest.config.ts
+++ b/back/jest.config.ts
@@ -1,0 +1,201 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+import type { Config } from "jest";
+
+const config: Config = {
+    // All imported modules in your tests should be mocked automatically
+    // automock: false,
+
+    // Stop running tests after `n` failures
+    // bail: 0,
+
+    // The directory where Jest should store its cached dependency information
+    // cacheDirectory: "C:\\Users\\33601\\AppData\\Local\\Temp\\jest",
+
+    // Automatically clear mock calls, instances, contexts and results before every test
+    clearMocks: true,
+
+    // Indicates whether the coverage information should be collected while executing the test
+    collectCoverage: true,
+
+    // An array of glob patterns indicating a set of files for which coverage information should be collected
+    // collectCoverageFrom: undefined,
+
+    // The directory where Jest should output its coverage files
+    coverageDirectory: "coverage",
+
+    // An array of regexp pattern strings used to skip coverage collection
+    // coveragePathIgnorePatterns: [
+    //   "\\\\node_modules\\\\"
+    // ],
+
+    // Indicates which provider should be used to instrument code for coverage
+    coverageProvider: "v8",
+
+    // A list of reporter names that Jest uses when writing coverage reports
+    // coverageReporters: [
+    //   "json",
+    //   "text",
+    //   "lcov",
+    //   "clover"
+    // ],
+
+    // An object that configures minimum threshold enforcement for coverage results
+    // coverageThreshold: undefined,
+
+    // A path to a custom dependency extractor
+    // dependencyExtractor: undefined,
+
+    // Make calling deprecated APIs throw helpful error messages
+    // errorOnDeprecated: false,
+
+    // The default configuration for fake timers
+    // fakeTimers: {
+    //   "enableGlobally": false
+    // },
+
+    // Force coverage collection from ignored files using an array of glob patterns
+    // forceCoverageMatch: [],
+
+    // A path to a module which exports an async function that is triggered once before all test suites
+    // globalSetup: undefined,
+
+    // A path to a module which exports an async function that is triggered once after all test suites
+    // globalTeardown: undefined,
+
+    // A set of global variables that need to be available in all test environments
+    // globals: {},
+
+    // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+    // maxWorkers: "50%",
+
+    // An array of directory names to be searched recursively up from the requiring module's location
+    // moduleDirectories: [
+    //   "node_modules"
+    // ],
+
+    // An array of file extensions your modules use
+    // moduleFileExtensions: [
+    //   "js",
+    //   "mjs",
+    //   "cjs",
+    //   "jsx",
+    //   "ts",
+    //   "tsx",
+    //   "json",
+    //   "node"
+    // ],
+
+    // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+    // moduleNameMapper: {},
+
+    // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+    // modulePathIgnorePatterns: [],
+
+    // Activates notifications for test results
+    // notify: false,
+
+    // An enum that specifies notification mode. Requires { notify: true }
+    // notifyMode: "failure-change",
+
+    // A preset that is used as a base for Jest's configuration
+    preset: "ts-jest",
+
+    // Run tests from one or more projects
+    // projects: undefined,
+
+    // Use this configuration option to add custom reporters to Jest
+    // reporters: undefined,
+
+    // Automatically reset mock state before every test
+    // resetMocks: false,
+
+    // Reset the module registry before running each individual test
+    // resetModules: false,
+
+    // A path to a custom resolver
+    // resolver: undefined,
+
+    // Automatically restore mock state and implementation before every test
+    // restoreMocks: false,
+
+    // The root directory that Jest should scan for tests and modules within
+    // rootDir: undefined,
+
+    // A list of paths to directories that Jest should use to search for files in
+    // roots: [
+    //   "<rootDir>"
+    // ],
+
+    // Allows you to use a custom runner instead of Jest's default test runner
+    // runner: "jest-runner",
+
+    // The paths to modules that run some code to configure or set up the testing environment before each test
+    // setupFiles: [],
+
+    // A list of paths to modules that run some code to configure or set up the testing framework before each test
+    // setupFilesAfterEnv: [],
+
+    // The number of seconds after which a test is considered as slow and reported as such in the results.
+    // slowTestThreshold: 5,
+
+    // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+    // snapshotSerializers: [],
+
+    // The test environment that will be used for testing
+    testEnvironment: "jest-environment-node",
+
+    // Options that will be passed to the testEnvironment
+    // testEnvironmentOptions: {},
+
+    // Adds a location field to test results
+    // testLocationInResults: false,
+
+    // The glob patterns Jest uses to detect test files
+    testMatch: [
+        "**/src/__tests__/**/*.test.ts",
+        // "**/__tests__/**/*.[jt]s?(x)",
+        // "**/?(*.)+(spec|test).[tj]s?(x)"
+    ],
+
+    // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+    // testPathIgnorePatterns: [
+    //   "\\\\node_modules\\\\"
+    // ],
+
+    // The regexp pattern or array of patterns that Jest uses to detect test files
+    // testRegex: [],
+
+    // This option allows the use of a custom results processor
+    // testResultsProcessor: undefined,
+
+    // This option allows use of a custom test runner
+    // testRunner: "jest-circus/runner",
+
+    // A map from regular expressions to paths to transformers
+    // transform: undefined,
+
+    // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+    // transformIgnorePatterns: [
+    //   "\\\\node_modules\\\\",
+    //   "\\.pnp\\.[^\\\\]+$"
+    // ],
+
+    // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+    // unmockedModulePathPatterns: undefined,
+
+    // Indicates whether each individual test should be reported during the run
+    // verbose: undefined,
+
+    // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+    // watchPathIgnorePatterns: [],
+
+    // Whether to use watchman for file crawling
+    // watchman: true,
+};
+
+export default config;
+

--- a/back/package.json
+++ b/back/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "src/index.ts",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "jest",
         "lint": "npx eslint --ext .ts src",
         "dev": "ts-node-dev --poll src/index.ts",
         "seed": "ts-node-dev src/seed.ts"
@@ -31,11 +31,15 @@
     "devDependencies": {
         "@types/cors": "2.8.17",
         "@types/express": "4.17.21",
+        "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "9.0.6",
         "@types/node": "20.14.9",
         "@typescript-eslint/eslint-plugin": "^7.15.0",
         "eslint": "8.56.0",
         "globals": "15.8.0",
+        "jest": "^29.7.0",
+        "supertest": "^7.0.0",
+        "ts-jest": "^29.2.0",
         "ts-node-dev": "2.0.0"
     }
 }

--- a/back/src/__tests__/HistoryResolver.test.ts
+++ b/back/src/__tests__/HistoryResolver.test.ts
@@ -1,0 +1,89 @@
+import HistoryResolver from "../resolvers/HistoryResolver";
+import { History } from "../entities/History";
+import { Url } from "../entities/Url";
+
+/**
+ * Partial : Permet de rendre toutes les propriétés d'un type optionnelles
+ * Permet donc de contourner le soucis de l'extends de BaseEntity
+ */
+
+type PartialHistory = Partial<History>;
+type PartialUrl = Partial<Url>;
+
+describe("HistoryResolver", () => {
+    let resolver: HistoryResolver;
+
+    beforeEach(() => {
+        resolver = new HistoryResolver();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("histories", () => {
+        it("should return an array of histories on success", async () => {
+            const mockUrl: PartialUrl = {
+                id: "123e4567-e89b-12d3-a456-426614174001",
+                name: "Test URL",
+                path: "https://example.com",
+            };
+            const mockHistories: PartialHistory[] = [
+                {
+                    id: "123e4567-e89b-12d3-a456-426614174000",
+                    status_code: 200,
+                    response: "OK",
+                    url: mockUrl as Url,
+                    created_at: new Date(),
+                },
+            ];
+            const findSpy = jest
+                .spyOn(History, "find")
+                .mockResolvedValue(mockHistories as History[]);
+
+            const result = await resolver.histories();
+
+            expect(result).toEqual(mockHistories);
+            expect(findSpy).toHaveBeenCalled();
+        });
+
+        it("should throw an error if the database query fails", async () => {
+            jest.spyOn(History, "find").mockRejectedValue(
+                new Error("Internal server error"),
+            );
+
+            await expect(resolver.histories()).rejects.toThrow(
+                "Internal server error",
+            );
+        });
+    });
+
+    describe("history", () => {
+        it("should return a single history on success", async () => {
+            const mockUrl: PartialUrl = {
+                id: "123e4567-e89b-12d3-a456-426614174001",
+                name: "Test URL",
+                path: "https://example.com",
+            };
+            const mockHistory: PartialHistory = {
+                id: "123e4567-e89b-12d3-a456-426614174000",
+                status_code: 200,
+                response: "OK",
+                url: mockUrl as Url,
+                created_at: new Date(),
+            };
+            const findOneByOrFailSpy = jest
+                .spyOn(History, "findOneByOrFail")
+                .mockResolvedValue(mockHistory as History);
+
+            const result = await resolver.history(
+                "123e4567-e89b-12d3-a456-426614174000",
+            );
+
+            expect(result).toEqual(mockHistory);
+            expect(findOneByOrFailSpy).toHaveBeenCalledWith({
+                id: "123e4567-e89b-12d3-a456-426614174000",
+            });
+        });
+    });
+});

--- a/back/src/__tests__/UrlRequest.test.ts
+++ b/back/src/__tests__/UrlRequest.test.ts
@@ -1,0 +1,123 @@
+import { UrlSubscriber } from "../subscribers/UrlSubscribers";
+import { Url } from "../entities/Url";
+import { History } from "../entities/History";
+import {
+    EntityManager,
+    InsertEvent,
+    UpdateEvent,
+    Connection,
+    QueryRunner,
+} from "typeorm";
+import axios from "axios";
+
+jest.mock("axios");
+
+describe("UrlSubscriber", () => {
+    let subscriber: UrlSubscriber;
+    let mockEntityManager: jest.Mocked<EntityManager>;
+    let mockUrl: Partial<Url>;
+    let mockConnection: Partial<Connection>;
+    let mockQueryRunner: Partial<QueryRunner>;
+
+    beforeEach(() => {
+        subscriber = new UrlSubscriber();
+        mockEntityManager = {
+            findOne: jest.fn(),
+            save: jest.fn(),
+            transaction: jest.fn((cb) => cb(mockEntityManager)),
+        } as unknown as jest.Mocked<EntityManager>;
+
+        mockUrl = {
+            id: "123e4567-e89b-12d3-a456-426614174000",
+            path: "https://example.com",
+        };
+
+        mockConnection = {} as Partial<Connection>;
+        mockQueryRunner = {} as Partial<QueryRunner>;
+
+        (axios.get as jest.Mock).mockResolvedValue({
+            data: "Mock response",
+            status: 200,
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should listen to Url entity", () => {
+        expect(subscriber.listenTo()).toBe(Url);
+    });
+
+    describe("afterInsert", () => {
+        it("should log URL response after insert", async () => {
+            const mockEvent: Partial<InsertEvent<Url>> = {
+                entity: mockUrl as Url,
+                manager: mockEntityManager,
+                connection: mockConnection as Connection,
+                queryRunner: mockQueryRunner as QueryRunner,
+                metadata: {} as any,
+            };
+
+            mockEntityManager.findOne.mockResolvedValue(mockUrl as Url);
+
+            await subscriber.afterInsert(mockEvent as InsertEvent<Url>);
+
+            expect(mockEntityManager.findOne).toHaveBeenCalledWith(Url, {
+                where: { id: mockUrl.id },
+            });
+            expect(axios.get).toHaveBeenCalledWith(mockUrl.path);
+            expect(mockEntityManager.save).toHaveBeenCalledWith(
+                expect.any(History),
+            );
+        });
+    });
+
+    describe("afterUpdate", () => {
+        it("should log URL response after update", async () => {
+            const mockEvent: Partial<UpdateEvent<Url>> = {
+                entity: mockUrl as Url,
+                manager: mockEntityManager,
+                connection: mockConnection as Connection,
+                queryRunner: mockQueryRunner as QueryRunner,
+                metadata: {} as any,
+            };
+
+            mockEntityManager.findOne.mockResolvedValue(mockUrl as Url);
+
+            await subscriber.afterUpdate(mockEvent as UpdateEvent<Url>);
+
+            expect(mockEntityManager.findOne).toHaveBeenCalledWith(Url, {
+                where: { id: mockUrl.id },
+            });
+            expect(axios.get).toHaveBeenCalledWith(mockUrl.path);
+            expect(mockEntityManager.save).toHaveBeenCalledWith(
+                expect.any(History),
+            );
+        });
+    });
+
+    it("should handle errors when logging URL response", async () => {
+        const mockEvent: Partial<InsertEvent<Url>> = {
+            entity: mockUrl as Url,
+            manager: mockEntityManager,
+            connection: mockConnection as Connection,
+            queryRunner: mockQueryRunner as QueryRunner,
+            metadata: {} as any,
+        };
+
+        mockEntityManager.findOne.mockResolvedValue(mockUrl as Url);
+        (axios.get as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+        const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+
+        await subscriber.afterInsert(mockEvent as InsertEvent<Url>);
+
+        expect(consoleSpy).toHaveBeenCalledWith(
+            "Failed to log URL response",
+            expect.any(Error),
+        );
+
+        consoleSpy.mockRestore();
+    });
+});

--- a/back/src/resolvers/HistoryResolver.ts
+++ b/back/src/resolvers/HistoryResolver.ts
@@ -1,19 +1,5 @@
-import { Resolver, Query, Mutation, Arg, InputType, Field } from "type-graphql";
+import { Resolver, Query, Arg } from "type-graphql";
 import { History } from "../entities/History";
-import { Url } from "../entities/Url";
-import { validate } from "class-validator";
-
-@InputType()
-class HistoryInput implements Partial<History> {
-    @Field()
-    status_code: number;
-
-    @Field()
-    response: string;
-
-    @Field()
-    urlId: string;
-}
 
 @Resolver()
 class HistoryResolver {
@@ -31,39 +17,6 @@ class HistoryResolver {
         try {
             return await History.findOneByOrFail({ id });
         } catch (error) {
-            throw new Error("Internal server error");
-        }
-    }
-
-    @Mutation(() => History)
-    async addHistory(
-        @Arg("historyData") historyData: HistoryInput,
-    ): Promise<History> {
-        try {
-            const url = await Url.findOneByOrFail({ id: historyData.urlId });
-            if (!url) {
-                throw new Error("URL not found");
-            }
-
-            const history = History.create({
-                ...historyData,
-                url: url,
-            });
-
-            const dataValidationError = await validate(history);
-            if (dataValidationError.length > 0) {
-                throw new Error("Data validation error");
-            }
-
-            await history.save();
-            return history;
-        } catch (error) {
-            if (
-                error.message === "Data validation error" ||
-                error.message === "URL not found"
-            ) {
-                throw new Error(error.message);
-            }
             throw new Error("Internal server error");
         }
     }


### PR DESCRIPTION
## [WILD-003](https://www.notion.so/WILD-003-Ping-l-URL-une-fois-sauvegarder-et-enregistrer-les-r-sultats-dans-la-table-History-135071873cf649cd8fb1372eb66531cd?pvs=4)

## Environnement concerné
*(cochez le cas correspondant)*

[ ] FrontEnd
[x] Backend

## Type de modifications
*(cochez le cas correspondant)*

[ ] Bugfix
[x] Feature
[ ] Refactoring

## Changements requis
*(cochez le cas correspondant)*

[ ] Ajout de variable(s) d'environnement
[ ] Modification de modèle (Migration à effectuer)
[x] Nouvelles dépendances à installer